### PR TITLE
Fix folder validation and cache updates

### DIFF
--- a/SimpleViewer/MainWindow.xaml.cs
+++ b/SimpleViewer/MainWindow.xaml.cs
@@ -166,11 +166,18 @@ namespace SimpleViewer
 
         private async void TextBoxImageFolder_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if (TextBoxImageFolder.Text.Trim() == "")
+            var folder = TextBoxImageFolder.Text.Trim();
+            if (string.IsNullOrWhiteSpace(folder))
             {
                 return;
             }
-            _imageCache = new ImageCache(TextBoxImageFolder.Text.Trim());
+
+            if (!Directory.Exists(folder))
+            {
+                return;
+            }
+
+            _imageCache = new ImageCache(folder);
 
             var fileCount = _imageCache.Prepare();
 
@@ -233,6 +240,7 @@ namespace SimpleViewer
         private async void ButtonBwdFast_Click(object sender, RoutedEventArgs e)
         {
             _ = await SetImageByOffsetAsync(-1 * SkipCount());
+            _imageCache.CasheImages(2, 2, SkipCount());
         }
 
         private int SkipCount()


### PR DESCRIPTION
## Summary
- validate directory exists before loading images
- update cache on backward skip for consistency

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684590f558dc8330899c33e0b5a601cc