### PR TITLE
Add ImageCache MSTest suite

### DIFF
--- a/SimpleViewer.Tests/ImageCacheTests.cs
+++ b/SimpleViewer.Tests/ImageCacheTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using SimpleViewer.Infrastructure;
+
+namespace SimpleViewer.Tests
+{
+    [TestClass]
+    public class ImageCacheTests
+    {
+        private static readonly byte[] PngData = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAOGNKoYAAAAASUVORK5CYII=");
+
+        private string CreateTempImages(int count)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            for (int i = 0; i < count; i++)
+            {
+                File.WriteAllBytes(Path.Combine(dir, $"{i}.png"), PngData);
+            }
+            return dir;
+        }
+
+        [TestMethod]
+        public async Task GetImageAsync_ReturnsImage()
+        {
+            var dir = CreateTempImages(2);
+            var cache = new ImageCache(dir);
+            cache.Prepare();
+
+            var image = await cache.GetImageAsync();
+
+            Assert.IsNotNull(image);
+            Assert.AreEqual("0.png", cache.CurrentFileName);
+
+            var image2 = await cache.GetImageAsync(1);
+            Assert.IsNotNull(image2);
+            Assert.AreEqual("1.png", cache.CurrentFileName);
+        }
+
+        [TestMethod]
+        public async Task ClearCache_RemovesOldItems()
+        {
+            var dir = CreateTempImages(3);
+            var cache = new ImageCache(dir);
+            cache.Prepare();
+
+            await cache.GetImageAsync();      // index 0
+            await cache.GetImageAsync(1);     // index 1
+            await cache.GetImageAsync(1);     // index 2
+
+            cache.CacheImages(0, 0, 0);       // only current index (2)
+            cache.ClearCache();
+
+            var store = cache.DebugGetImageStore();
+            Assert.IsTrue(store.ContainsKey(2));
+            Assert.IsFalse(store.ContainsKey(0));
+            Assert.IsFalse(store.ContainsKey(1));
+        }
+
+        [TestMethod]
+        public async Task CacheImages_WithSkipCount_PopulatesFuture()
+        {
+            var dir = CreateTempImages(5);
+            var cache = new ImageCache(dir);
+            cache.Prepare();
+
+            cache.CacheImages(0, 0, 2);
+
+            var status = cache.DebugGetStatus();
+            Assert.IsNotNull(status[0]);
+            Assert.IsNotNull(status[2]);
+            await status[2];
+            var store = cache.DebugGetImageStore();
+            Assert.IsTrue(store.ContainsKey(2));
+        }
+    }
+}

--- a/SimpleViewer.Tests/Properties/AssemblyInfo.cs
+++ b/SimpleViewer.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SimpleViewer.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SimpleViewer.Tests")]
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SimpleViewer.Tests/SimpleViewer.Tests.csproj
+++ b/SimpleViewer.Tests/SimpleViewer.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleViewer.Infrastructure\SimpleViewer.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/SimpleViewer.sln
+++ b/SimpleViewer.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleViewer", "SimpleViewe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleViewer.Infrastructure", "SimpleViewer.Infrastructure\SimpleViewer.Infrastructure.csproj", "{B55E5A2C-D98C-4E0E-9FDA-AD356AA5AA93}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleViewer.Tests", "SimpleViewer.Tests\SimpleViewer.Tests.csproj", "{B51D50CE-26C2-4784-B41F-23D83439D40F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,9 +21,13 @@ Global
 		{F54071FC-4F02-4841-B117-F73D16970EF2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B55E5A2C-D98C-4E0E-9FDA-AD356AA5AA93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B55E5A2C-D98C-4E0E-9FDA-AD356AA5AA93}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B55E5A2C-D98C-4E0E-9FDA-AD356AA5AA93}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B55E5A2C-D98C-4E0E-9FDA-AD356AA5AA93}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {B55E5A2C-D98C-4E0E-9FDA-AD356AA5AA93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B55E5A2C-D98C-4E0E-9FDA-AD356AA5AA93}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B51D50CE-26C2-4784-B41F-23D83439D40F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B51D50CE-26C2-4784-B41F-23D83439D40F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B51D50CE-26C2-4784-B41F-23D83439D40F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B51D50CE-26C2-4784-B41F-23D83439D40F}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add MSTest project `SimpleViewer.Tests`
- test `GetImageAsync` image retrieval
- test `ClearCache` removing old items
- test `CacheImages` populates skip items
- include the test project in the solution

## Testing
- `dotnet test SimpleViewer.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684594e9fd2883309fdaf82dab5b2d7b